### PR TITLE
Update PyTorch Compatibility and GPU Handling

### DIFF
--- a/imagenet.py
+++ b/imagenet.py
@@ -119,7 +119,7 @@ parser.add_argument('--manualSeed', type=int, help='manual seed')
 parser.add_argument('-e', '--evaluate', dest='evaluate', action='store_true',
                     help='evaluate model on validation set')
 # Device options
-parser.add_argument('--gpu-id', default='7', type=str,
+parser.add_argument('--gpu-id', default='0', type=str,
                     help='id(s) for CUDA_VISIBLE_DEVICES')
 
 # Core of debiased training
@@ -185,7 +185,7 @@ def main():
                                      std=[0.229, 0.224, 0.225])
 
     transform_train = transforms.Compose([
-        transforms.RandomSizedCrop(224),
+        transforms.RandomResizedCrop(224), # change from RandomSizedCrop'to  'RandomResizedCrop'
         transforms.RandomHorizontalFlip(),
         transforms.ToTensor(),
         # normalize,  # normalization should be after style transfer module
@@ -201,7 +201,7 @@ def main():
     ]
     if not args.already224:
         # This option is for evaluating Stylized-ImageNet, which is already 224x224
-        val_transforms = [transforms.Scale(256), transforms.CenterCrop(224)] + val_transforms
+        val_transforms = [transforms.Resize(256), transforms.CenterCrop(224)] + val_transforms # torchvision.transforms.Resize  'torchvision.transforms.Scale'
     val_loader = torch.utils.data.DataLoader(
         datasets.ImageFolder(valdir, transforms.Compose(val_transforms)),
         batch_size=args.test_batch, shuffle=False,

--- a/utils/eval.py
+++ b/utils/eval.py
@@ -13,6 +13,6 @@ def accuracy(output, target, topk=(1,)):
 
     res = []
     for k in topk:
-        correct_k = correct[:k].view(-1).float().sum(0)
+        correct_k = correct[:k].reshape(-1).float().sum(0)  
         res.append(correct_k.mul_(100.0 / batch_size))
     return res


### PR DESCRIPTION
Solving issues with the current version of PyTorch.
 **Changes Made:**
Replaced transforms.RandomSizedCrop(224) with transforms.RandomResizedCrop(224)  for random resizing and cropping of images.
Deprecated the use of transforms.Scale and replaced it with transforms.Resize for image resizing.
Set the CUDA device to 0 to avoid the error "No CUDA GPUs are available" in ImageNet.py scripts. 